### PR TITLE
Add GitHub reporter agent to QA workflow and update state management

### DIFF
--- a/agents/assign_worker.py
+++ b/agents/assign_worker.py
@@ -2,7 +2,6 @@ from langchain_openai import ChatOpenAI
 from typing import Dict, Any, List, Optional
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
-from langgraph.prebuilt import create_react_agent
 from states import QaWorkflowState
 
 load_dotenv()
@@ -18,7 +17,7 @@ def assign_worker_node(state: QaWorkflowState) -> QaWorkflowState:
     llm = ChatOpenAI(model="gpt-4o-mini")
     structured_llm = llm.with_structured_output(AssignWorkerAgentOutput)
     response = structured_llm.invoke("You are a QA manager. You are given a code diff and an issue description of a pull request. "
-                                     "You need to assign the appropriate agents to test the pull request. If the issue "
+                                     "You need to assign the appropriate agents to test the pull request."
                                      "The agents are: \n"
                                      "- 'accessibility_scan': this a accessibility test agent\n"
                                      "- 'security_scan': this is a security test agent\n"

--- a/agents/github_reporter.py
+++ b/agents/github_reporter.py
@@ -1,0 +1,58 @@
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+from langgraph.prebuilt import create_react_agent
+from dotenv import load_dotenv
+import asyncio
+from typing import Dict, Any, List, Optional
+from states import QaWorkflowState
+import os
+from pydantic import BaseModel, Field
+
+load_dotenv()
+
+mcp_client = MultiServerMCPClient({
+   "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+      },
+      "transport": "stdio",
+    }
+})
+
+class GithubResponse(BaseModel):
+    report: str = Field(description="The report of the test results, agents used and reasoning of the used agents")
+    errors: Optional[List[str]] = Field(None, description="A list of error messages, if any occurred during the report generation.")
+
+async def run_github_reporter(state: QaWorkflowState) -> QaWorkflowState:
+    repo = state.get("repo")
+    pr_number = state.get("pr_number")
+    agents_needed = state.get("agents_needed")
+    reasoning = state.get("reasoning")
+    ui_test_results = state.get("ui_test_results", [])
+    accessibility_scan_results = state.get("accessibility_scan_results", [])
+    security_test_results = state.get("security_test_results", [])
+    all_test_results = ui_test_results + accessibility_scan_results + security_test_results
+    async with mcp_client.session("github") as session:
+        tools = await load_mcp_tools(session)
+        agent = create_react_agent(model="gpt-4o-mini", tools=tools, response_format=GithubResponse)
+        response = await agent.ainvoke({"messages": [{"role": "user", "content": f"Use the GitHub tool to post a review comment on pull request #{pr_number} in repository {repo} with a report of the test results, agents used and reasoning of the used agents.\n"
+                                                         f"The test results: {all_test_results}\n"
+                                                         f"The agents used: {agents_needed}\n"
+                                                         f"The reasoning of the used agents: ${reasoning}"}]})
+    structured_response = response["structured_response"]
+    return {
+        "report": structured_response.report,
+        "errors": structured_response.errors
+    }
+
+def github_reporter_node(state: QaWorkflowState) -> QaWorkflowState:
+    return asyncio.run(run_github_reporter(state))

--- a/agents/test_design.py
+++ b/agents/test_design.py
@@ -26,7 +26,7 @@ def test_design_node(state: QaWorkflowState) -> QaWorkflowState:
     messages = [
         {"role": "system", "content": "You are a test design assistant. You are given a code diff and an issue description of a pull request. "
         "You generete test cases for the agents that are given to you."
-        "For the ui_test agent, you need to generate test cases that cover the happy flow of the functionality."
+        "For the ui_test agent, you need to generate test cases that cover the happy flow of the functionality. These test cases will be executed by a browser agent."
         "For the accessibility_test agent, you need to generate test cases that cover the accessibility of the functionality."
         "For the security_test agent, you need to generate test cases that cover the security of the functionality."
         "The test cases should be suitable for the selected agent(s) and also be added to the list of testcases for the agent."},
@@ -35,7 +35,6 @@ def test_design_node(state: QaWorkflowState) -> QaWorkflowState:
         f"Code diff: {code}. Issue description: {issue}"}
     ]
     response = structured_llm.invoke(messages)
-    print(response)
     return {
         "testcases_ui_test": response.testcases_ui_test,
         "testcases_accessibility_test": response.testcases_accessibility_test,

--- a/qa_workflow.py
+++ b/qa_workflow.py
@@ -6,6 +6,7 @@ from agents.ui_test import ui_test_node
 from agents.assign_worker import assign_worker_node
 from agents.accessibility_test import accessibility_test_node
 from agents.security_test import security_test_node
+from agents.github_reporter import github_reporter_node
 from pprint import pprint
 
 
@@ -17,6 +18,7 @@ graph_builder.add_node("test_design", test_design_node)
 graph_builder.add_node("ui_test", ui_test_node)
 graph_builder.add_node("accessibility_scan", accessibility_test_node)
 graph_builder.add_node("security_scan", security_test_node)
+graph_builder.add_node("github_reporter", github_reporter_node)
 
 graph_builder.add_edge(START, "github_agent")
 graph_builder.add_edge("github_agent", "assign_worker")
@@ -26,9 +28,10 @@ graph_builder.add_conditional_edges("test_design", lambda state: state.get("agen
     "accessibility_scan": "accessibility_scan",
     "security_scan": "security_scan",
 })
-graph_builder.add_edge("ui_test", END)
-graph_builder.add_edge("accessibility_scan", END)
-graph_builder.add_edge("security_scan", END)
+graph_builder.add_edge("ui_test", "github_reporter")
+graph_builder.add_edge("accessibility_scan", "github_reporter")
+graph_builder.add_edge("security_scan", "github_reporter")
+graph_builder.add_edge("github_reporter", END)
 
 
 workflow = graph_builder.compile()

--- a/states.py
+++ b/states.py
@@ -15,4 +15,7 @@ class QaWorkflowState(TypedDict):
     github_issue: Optional[dict]
     pr_code_changes: Optional[str]
     ui_test_results: Optional[List[dict]]
+    accessibility_scan_results: Optional[List[dict]]
+    security_test_results: Optional[List[dict]]
     errors: Optional[List[str]]
+    report: Optional[str]


### PR DESCRIPTION
- Introduced a new GitHub reporter agent to generate reports on test results and agent usage.
- Updated the workflow to include the GitHub reporter node and adjusted the flow to connect test agents to the reporter.
- Enhanced the QaWorkflowState to include fields for accessibility and security scan results, as well as a report field for generated outputs.
- Refined the test design agent's messaging to clarify the execution context for UI tests.